### PR TITLE
[hotfix] vite build 時、パスに build/ を付けないようにした。

### DIFF
--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -48,7 +48,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(),
   routes,
 });
 


### PR DESCRIPTION
vite build 時、パスに build/ を付けないようにしました。
これにより、本番環境でパスに build/ が付きません。

確認よろしくお願いします。