### PR TITLE
gtagメソッドの引数を、公式と同じ文字列に変更。

### DIFF
--- a/resources/views/ga.blade.php
+++ b/resources/views/ga.blade.php
@@ -5,5 +5,5 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', {{ config('google.ga_measurement_id') }});
+  gtag('config', '{{ config('google.ga_measurement_id') }}');
 </script>


### PR DESCRIPTION
gtagメソッドの引数を、公式と同じ文字列に変更。